### PR TITLE
Fix up an infinite loop in Javascript that forbids the page from loading

### DIFF
--- a/inst/javascript/arrayQualityMetrics.js
+++ b/inst/javascript/arrayQualityMetrics.js
@@ -78,18 +78,10 @@ function setReportObj(reportObjId, status, doTable)
 	}
     } else {
     /* This works in Firefox 4 */
-	var success = false;
-	i = 0; 
-	/* Some of this looping could already be cached in reportInit() */
-	while( (!success) & (i < ssrules.length) ) {
-	    selector = ssrules[i].selectorText;  // The selector 
-            if (!selector) 
-		continue; // Skip @import and other nonstyle rules
-            if (selector == (".aqm" + reportObjId)) {
-		success = true; 
+    for(i=0; i<ssrules.length; i++) {
+        if (ssrules[i].selectorText == (".aqm" + reportObjId)) {
 		ssrules[i].style.cssText = cssText[0+status];
-	    } else {
-		i++;
+		break;
 	    }
 	}
     }


### PR DESCRIPTION
The original loop has  `if (!selector) continue` without incrementing the counter, so the javascript engine just spins and - in my browser - doesn't load the page.

Compare:

(with the fix)
https://wwwdev.ebi.ac.uk/gxa/experiments/E-MTAB-3201/Supplementary%20Information

(problematic, in newest Chrome/Firefox the second page doesn't load)
https://www.ebi.ac.uk/gxa/experiments/E-MTAB-3201/Supplementary%20Information

By the way I use this bash routine to modify an existing generated Javascript file into a different template, take it if it's helpful to you:
```
fixArrayQualityMetricsFile(){
	generatedFile=$1
	correctFile=$2
	matchPhrase='var highlightInitial\|var arrayMetadata\|var svgObjectNames'

	echo "/* patch part 1 - lines from generated file */"
	grep "$matchPhrase" < "$generatedFile"
    echo "/* patch part 2 - lines from patch file */"
	grep -v "$matchPhrase" < "$correctFile"
}
```
